### PR TITLE
[semver:major] upgraded dependency-check to the latest version (9.0.7)

### DIFF
--- a/src/commands/run-dependency-check.yml
+++ b/src/commands/run-dependency-check.yml
@@ -7,7 +7,7 @@ parameters:
     description: "Name used by OWASP Dependency Check"
   version:
     type: string
-    default: "7.4.4"
+    default: "9.0.7"
     description: "OWASP Dependency Check Version"
   report_path:
     type: string
@@ -41,7 +41,7 @@ steps:
           --volume $(pwd)/app.properties:/app.properties:z \
           --volume $(pwd)/<< parameters.root_dir >>/<< parameters.report_path >>:/report:z \
           owasp/dependency-check:<< parameters.version >> \
-          --scan /src --format "ALL" --ossIndexUsername $OSS_INDEX_USERNAME --ossIndexPassword $OSS_INDEX_PASSWORD --project "<< parameters.project_name >>"  --out /report --cveValidForHours 24 --propertyfile /app.properties
+          --scan /src --format "ALL" --ossIndexUsername $OSS_INDEX_USERNAME --ossIndexPassword $OSS_INDEX_PASSWORD --nvdApiKey $NVD_API_KEY --project "<< parameters.project_name >>"  --out /report --cveValidForHours 24 --propertyfile /app.properties
   - save_cache:
       paths:
         - dependency-audit-data

--- a/src/jobs/run-audit.yml
+++ b/src/jobs/run-audit.yml
@@ -75,7 +75,7 @@ parameters:
     default: false
   dependency_check_version:
     type: string
-    default: "7.4.4"
+    default: "9.0.7"
     description: "OWASP Dependency Check Version"
   dependency_report_path:
     type: string

--- a/src/jobs/run-dependency-check.yml
+++ b/src/jobs/run-dependency-check.yml
@@ -8,7 +8,7 @@ parameters:
     description: "Name used by OWASP Dependency Check"
   version:
     type: string
-    default: "7.4.4"
+    default: "9.0.7"
     description: "OWASP Dependency Check Version"
   report_path:
     type: string


### PR DESCRIPTION
[9.0.0 Upgrade notice](https://github.com/jeremylong/DependencyCheck?tab=readme-ov-file#900-upgrade-notice):

> ![image](https://github.com/luxurypresence/sonarqube-orb/assets/12860102/f64f32ab-cb62-4419-8711-0cc53c0bcf4e)

Considerations and questions:

- I've created a new NVD API key with our email infra@luxurypresence.com and saved it in 1Password (Engineering / NVD API Key). Additionally, I've added it as an environment variable in the orb-publishing context in CircleCI.
- I don't think we'll have problems with rate limiting, as we are already using a caching strategy. Any concerns?
- I'm pretty sure we are using the embedded H2 database, right?