### PR TITLE
[semver:minor] Add `no_output_timeout` to run-scanner

### DIFF
--- a/src/commands/run-scanner.yml
+++ b/src/commands/run-scanner.yml
@@ -79,6 +79,10 @@ parameters:
     type: string
     description: "Node max space"
     default: "4096"
+  no_output_timeout:
+    type: string
+    description: Elapsed time the command can run without output. Passed to install command.
+    default: "10m"
 
 steps:
   - run:
@@ -136,6 +140,7 @@ steps:
           -Dsonar.dependencyCheck.htmlReportPath=<< parameters.root_dir >>/<< parameters.html_report_path >> \
           -Dsonar.javascript.node.maxspace=<< parameters.node_max_space >> \
           $SONAR_CMD_SCOPE
+      no_output_timeout: << parameters.no_output_timeout >>
       environment:
         SERVER_URL: << parameters.host_url >>
         LOGIN_TOKEN: << parameters.login_token >>

--- a/src/jobs/run-audit.yml
+++ b/src/jobs/run-audit.yml
@@ -89,6 +89,10 @@ parameters:
     type: string
     description: "Node max space"
     default: "4096"
+  no_output_timeout:
+    type: string
+    description: Elapsed time the command can run without output. Passed to install command.
+    default: "10m"
 
 steps:
   - checkout
@@ -118,3 +122,4 @@ steps:
       build_pr: << parameters.pull_request >>
       root_dir: << parameters.root_dir >>
       node_max_space: << parameters.node_max_space >>
+      no_output_timeout: << parameters.no_output_timeout >>


### PR DESCRIPTION
## Issue Description

The `sonarqube/run-audit` check has been failing on `luxurypresence/dashboard` for every PR since February 5. There probably needs to be a better fix but increasing the timeout may solve our issues in the short term and it's easily reversible. 

The last time it passed, one of the tests ran for 565 seconds (9min 25s) so I'd like to (temporarily) increase the timeout to 20 minutes to see if it passes in order to narrow down the problem. 

For more info/context: https://luxurypresence.slack.com/archives/C01K6PQ7E5B/p1708036796986409?thread_ts=1707323169.891029&cid=C01K6PQ7E5B

I'm pretty sure this should work based on the CircleCI docs: https://circleci.com/docs/configuration-reference/#modifiers:~:text=default%3A%20.)-,no_output_timeout,-N