### PR TITLE
[semver:patch] Move `no_output_timeout` to correct job

### DIFF
--- a/src/commands/run-dependency-check.yml
+++ b/src/commands/run-dependency-check.yml
@@ -17,6 +17,10 @@ parameters:
     type: string
     description: "Root location of the sources to analyze"
     default: "."
+  no_output_timeout:
+    type: string
+    description: Elapsed time the command can run without output. Passed to install command.
+    default: "10m"
 
 steps:
   - run:
@@ -42,6 +46,7 @@ steps:
           --volume $(pwd)/<< parameters.root_dir >>/<< parameters.report_path >>:/report:z \
           owasp/dependency-check:<< parameters.version >> \
           --scan /src --format "ALL" --ossIndexUsername $OSS_INDEX_USERNAME --ossIndexPassword $OSS_INDEX_PASSWORD --nvdApiKey $NVD_API_KEY --project "<< parameters.project_name >>" --nvdApiDelay $NVD_API_DELAY --out /report --nvdValidForHours 24 --propertyfile /app.properties
+      no_output_timeout: << parameters.no_output_timeout >>
   - save_cache:
       paths:
         - dependency-audit-data

--- a/src/commands/run-scanner.yml
+++ b/src/commands/run-scanner.yml
@@ -79,10 +79,6 @@ parameters:
     type: string
     description: "Node max space"
     default: "4096"
-  no_output_timeout:
-    type: string
-    description: Elapsed time the command can run without output. Passed to install command.
-    default: "10m"
 
 steps:
   - run:
@@ -140,7 +136,6 @@ steps:
           -Dsonar.dependencyCheck.htmlReportPath=<< parameters.root_dir >>/<< parameters.html_report_path >> \
           -Dsonar.javascript.node.maxspace=<< parameters.node_max_space >> \
           $SONAR_CMD_SCOPE
-      no_output_timeout: << parameters.no_output_timeout >>
       environment:
         SERVER_URL: << parameters.host_url >>
         LOGIN_TOKEN: << parameters.login_token >>

--- a/src/jobs/run-audit.yml
+++ b/src/jobs/run-audit.yml
@@ -103,6 +103,7 @@ steps:
       version: << parameters.dependency_check_version >>
       report_path: << parameters.dependency_report_path >>
       root_dir: << parameters.root_dir >>
+      no_output_timeout: << parameters.no_output_timeout >>
   - run-scanner:
       scanner_version: << parameters.scanner_version >>
       host_url: << parameters.host_url >>
@@ -122,4 +123,3 @@ steps:
       build_pr: << parameters.pull_request >>
       root_dir: << parameters.root_dir >>
       node_max_space: << parameters.node_max_space >>
-      no_output_timeout: << parameters.no_output_timeout >>


### PR DESCRIPTION
I introduced the param to the wrong command in #30 🤦 

The command that's failing is `Run OWASP Dependency Check`

https://app.circleci.com/pipelines/github/luxurypresence/dashboard/19585/workflows/a3678421-81f9-4de3-8546-2a4ad6ec76b4/jobs/63601?invite=true#step-106-11422_67